### PR TITLE
Add gradio placeholder UI

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1,0 +1,46 @@
+import gradio as gr
+
+# Placeholder functions for backend operations
+
+def start_training(args, subsets, queue, backend_url):
+    # This would normally trigger the backend training process
+    print('Start training called')
+    return "Training started with placeholder implementation"
+
+# Basic layout mimicking the PySide6 GUI
+with gr.Blocks(title="LoRA Trainer") as demo:
+    with gr.Row():
+        with gr.Column(scale=3):
+            with gr.Tabs() as tabs:
+                with gr.Tab("Main Args"):
+                    with gr.Accordion("General Args", open=True):
+                        general = gr.Textbox(label="General settings", placeholder="...")
+                    with gr.Accordion("Network Args"):
+                        network = gr.Textbox(label="Network settings", placeholder="...")
+                    with gr.Accordion("Optimizer Args"):
+                        optimizer = gr.Textbox(label="Optimizer settings", placeholder="...")
+                    with gr.Accordion("Saving Args"):
+                        saving = gr.Textbox(label="Saving settings", placeholder="...")
+                    with gr.Accordion("Bucket Args"):
+                        bucket = gr.Textbox(label="Bucket settings", placeholder="...")
+                    with gr.Accordion("Noise Offset Args"):
+                        noise_offset = gr.Textbox(label="Noise Offset settings", placeholder="...")
+                    with gr.Accordion("Sample Args"):
+                        sample = gr.Textbox(label="Sample settings", placeholder="...")
+                    with gr.Accordion("Logging Args"):
+                        logging = gr.Textbox(label="Logging settings", placeholder="...")
+                    with gr.Accordion("Flux Args"):
+                        flux = gr.Textbox(label="Flux settings", placeholder="...")
+                    with gr.Accordion("Extra Args"):
+                        extra = gr.Textbox(label="Extra settings", placeholder="...")
+                with gr.Tab("Subset Args"):
+                    subsets = gr.Dataframe(headers=["Subset Path", "Repeats"], datatype=["str", "number"], label="Subsets")
+        with gr.Column(scale=1):
+            queue = gr.Dataframe(headers=["Queue Item"], datatype=["str"], label="Queue")
+            backend_url = gr.Textbox(value="http://127.0.0.1:8000", label="Backend Server URL")
+            start_btn = gr.Button("Start Training")
+            output = gr.Textbox(label="Output", interactive=False)
+    start_btn.click(start_training, inputs=[general, subsets, queue, backend_url], outputs=output)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyside6
 qt-material==2.14
 toml
 requests
+gradio


### PR DESCRIPTION
## Summary
- add a `gradio_app.py` script providing a basic interface that mirrors the PySide6 GUI layout
- include gradio in `requirements.txt`

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile gradio_app.py`
- `python gradio_app.py` (terminated after launch)

------
https://chatgpt.com/codex/tasks/task_e_6867709c5cf483339fe9ff90472a3a7b